### PR TITLE
Add a noop implementation for ccache for darwin 

### DIFF
--- a/krb5ssp/ccache_darwin.go
+++ b/krb5ssp/ccache_darwin.go
@@ -1,0 +1,33 @@
+// MIT License
+//
+// # Copyright (c) 2024 Jimmy Fjällid
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package krb5ssp
+
+import (
+	"fmt"
+	"github.com/jfjallid/gokrb5/v8/client"
+	"github.com/jfjallid/gokrb5/v8/config"
+)
+
+func getClientFromCachedTicket(cfg *config.Config, username, domain, spn string) (c *client.Client, err error) {
+	return nil, fmt.Errorf("CCACHE files not implemented on Darwin")
+}


### PR DESCRIPTION
The library cannot be compiled on MacOS currently because there is no darwin implementation for `getClientFromCachedTicket`. I'm not sure if there's a good way to actually implement it, but at least to make it compile I copied the "unimplemented" implementation from windows to make it compile on MacOS.